### PR TITLE
Fix incorrect spigot download link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Join us on [Discord](https://discord.badbones69.com)
 ## Downloads
 [![Build Status](https://jenkins.badbones69.com/view/Stable/job/Crazy-Crates/badge/icon)](https://jenkins.badbones69.com/view/Stable/job/Crazy-Crates/)
 
-Downloads can be obtained from the [spigot page](https://www.spigotmc.org/resources/crazy-crates.16470/) or the [Jenkins](https://jenkins.badbones69.com/view/Stable/job/Crazy-Crates/).
+Downloads can be obtained from the [spigot page](https://www.spigotmc.org/resources/crazy-crates.17599/) or the [Jenkins](https://jenkins.badbones69.com/view/Stable/job/Crazy-Crates/).
 
 ## Plugin Data
 [![bStats Graph Data](https://bstats.org/signatures/bukkit/CrazyCrates.svg)](https://bstats.org/plugin/bukkit/CrazyCrates/4514)


### PR DESCRIPTION
For some reason, the download link for spigot was pointing towards CrazyEnchantments instead of CrazyCrates