### PR TITLE
Add Permission to prevent keys from giveAll & Fix permission link

### DIFF
--- a/src/main/java/com/badbones69/crazycrates/api/enums/Permissions.java
+++ b/src/main/java/com/badbones69/crazycrates/api/enums/Permissions.java
@@ -8,6 +8,8 @@ public enum Permissions {
     CRAZY_CRATES_PLAYER_MENU("player.menu", "Opens the primary crate menu."),
     CRAZY_CRATES_PLAYER_HELP("player.help", "Shows the help menu for Crazy Crates."),
 
+    CRAZY_CRATES_PLAYER_EXCLUDE_GIVE_ALL("exclude.player.giveall", "Permission to prevent a player from getting keys from /GiveAll."),
+
     CRAZY_CRATES_ADMIN_HELP("admin.help", "Shows the help menu for admins"),
     CRAZY_CRATES_ADMIN_ACCESS("admin.access", "General purpose access for admins."),
     CRAZY_CRATES_ADMIN_ADD_ITEM("admin.additem", "Adds items in-game to a prize in a crate."),

--- a/src/main/java/com/badbones69/crazycrates/api/enums/Permissions.java
+++ b/src/main/java/com/badbones69/crazycrates/api/enums/Permissions.java
@@ -10,11 +10,11 @@ public enum Permissions {
 
     CRAZY_CRATES_PLAYER_EXCLUDE_GIVE_ALL("exclude.player.giveall", "Permission to prevent a player from getting keys from /GiveAll."),
 
-    CRAZY_CRATES_ADMIN_HELP("admin.help", "Shows the help menu for admins"),
+    CRAZY_CRATES_ADMIN_HELP("admin.help", "Shows the help menu for admins."),
     CRAZY_CRATES_ADMIN_ACCESS("admin.access", "General purpose access for admins."),
     CRAZY_CRATES_ADMIN_ADD_ITEM("admin.additem", "Adds items in-game to a prize in a crate."),
     CRAZY_CRATES_ADMIN_PREVIEW("admin.preview", "Opens the preview of any crate for a player."),
-    CRAZY_CRATES_ADMIN_LIST("admin.list", "Displays a list of all available crates"),
+    CRAZY_CRATES_ADMIN_LIST("admin.list", "Displays a list of all available crates."),
     CRAZY_CRATES_ADMIN_OPEN("admin.open", "Tries to open a crate for the player if they have a key."),
     CRAZY_CRATES_ADMIN_OPEN_OTHER("admin.open.others", "Tries to open a crate for a player if they have a key."),
     CRAZY_CRATES_ADMIN_FORCE_OPEN("admin.forceopen", "Opens a crate for a player for free."),
@@ -27,7 +27,7 @@ public enum Permissions {
     CRAZY_CRATES_ADMIN_RELOAD("admin.reload", "Reloads the entire plugin."),
     CRAZY_CRATES_ADMIN_DEBUG("admin.debug", "Debugs the plugin."),
     CRAZY_CRATES_ADMIN_CONVERT("admin.convert", "Converts data from other supported crate plugins into crazy crates."),
-    CRAZY_CRATES_ADMIN_SCHEMATIC("admin.schematic.*", "Gives all permissions related to schematics"),
+    CRAZY_CRATES_ADMIN_SCHEMATIC("admin.schematic.*", "Gives all permissions related to schematics."),
     CRAZY_CRATES_ADMIN_SCHEMATIC_SET("admin.schematic.set", "Sets the positions #1 or #2 when making a new schematic for quadcrates."),
     CRAZY_CRATES_ADMIN_SCHEMATIC_SAVE("admin.schematic.save", "Saves the new schematic file to the schematics folder.");
 

--- a/src/main/java/com/badbones69/crazycrates/commands/subs/CrateBaseCommand.java
+++ b/src/main/java/com/badbones69/crazycrates/commands/subs/CrateBaseCommand.java
@@ -530,7 +530,7 @@ public class CrateBaseCommand extends BaseCommand {
 
                 for (Player onlinePlayer : plugin.getServer().getOnlinePlayers()) {
 
-                    if (Methods.permCheck(onlinePlayer, Permissions.CRAZY_CRATES_PLAYER_EXCLUDE_GIVE_ALL, false)) continue;
+                    if (Methods.permCheck(onlinePlayer, Permissions.CRAZY_CRATES_PLAYER_EXCLUDE_GIVE_ALL, true)) continue;
 
                     PlayerReceiveKeyEvent event = new PlayerReceiveKeyEvent(onlinePlayer, crate, PlayerReceiveKeyEvent.KeyReceiveReason.GIVE_ALL_COMMAND, amount);
                     onlinePlayer.getServer().getPluginManager().callEvent(event);

--- a/src/main/java/com/badbones69/crazycrates/commands/subs/CrateBaseCommand.java
+++ b/src/main/java/com/badbones69/crazycrates/commands/subs/CrateBaseCommand.java
@@ -6,6 +6,7 @@ import com.badbones69.crazycrates.api.CrazyManager;
 import com.badbones69.crazycrates.api.FileManager;
 import com.badbones69.crazycrates.api.enums.CrateType;
 import com.badbones69.crazycrates.api.enums.KeyType;
+import com.badbones69.crazycrates.api.enums.Permissions;
 import com.badbones69.crazycrates.api.enums.settings.Messages;
 import com.badbones69.crazycrates.api.events.PlayerReceiveKeyEvent;
 import com.badbones69.crazycrates.api.objects.Crate;
@@ -528,6 +529,9 @@ public class CrateBaseCommand extends BaseCommand {
                 sender.sendMessage(Messages.GIVEN_EVERYONE_KEYS.getMessage(placeholders));
 
                 for (Player onlinePlayer : plugin.getServer().getOnlinePlayers()) {
+
+                    if (Methods.permCheck(onlinePlayer, Permissions.CRAZY_CRATES_PLAYER_EXCLUDE_GIVE_ALL, false)) continue;
+
                     PlayerReceiveKeyEvent event = new PlayerReceiveKeyEvent(onlinePlayer, crate, PlayerReceiveKeyEvent.KeyReceiveReason.GIVE_ALL_COMMAND, amount);
                     onlinePlayer.getServer().getPluginManager().callEvent(event);
 

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -84,4 +84,4 @@ Messages:
     - '&6/key [player] &7- &eCheck the number of keys a player has.'
     - '&6/cc &7- &eOpens the menu.'
     - ' '
-    - '&7You can find a list of permissions @ &ehttps://github.com/badbones69/CrazyCrates/wiki/Commands-and-Permissions'
+    - '&7You can find a list of permissions @ &ehttps://github.com/Crazy-Crew/CrazyCrates/wiki/Commands-and-Permissions'


### PR DESCRIPTION
- Added new permission "crazycrates.command.exclude.player.giveall" which will exclude you from getting crates from /cc giveAll.
- Added missing periods in some permission descriptions.
- Fixed the permission link in messages.yml so that newer users can get a working link to the permissions page.

Had no clue what the permission name should be and can make changes if needed.
Not sure if it should also tell them who (did/did not) get keys or amount of players that (did/did not) get them.