### PR TITLE
Fix applying knockback when disabled and in GUI

### DIFF
--- a/src/main/java/com/badbones69/crazycrates/commands/subs/CrateBaseCommand.java
+++ b/src/main/java/com/badbones69/crazycrates/commands/subs/CrateBaseCommand.java
@@ -328,7 +328,7 @@ public class CrateBaseCommand extends BaseCommand {
                         }
 
                         player.sendMessage(Messages.NO_VIRTUAL_KEY.getMessage());
-                        CrateControlListener.knockBack(player, player.getTargetBlock(null, 1).getLocation().add(.5, 0, .5));
+                        if (config.getBoolean("Settings.KnockBack")) CrateControlListener.knockBack(player, player.getTargetBlock(null, 1).getLocation());
                         return;
                     }
 


### PR DESCRIPTION
In response to an issue I reported on discord of knockback being applied when disabled and in the crates GUI ([Discord message](https://discord.com/channels/182615261403283459/196107841449361408/1045827979185504356)).
Added an If statement to knockback applied in the `openCrate` function.
```java
if (config.getBoolean("Settings.KnockBack")) CrateControlListener.knockBack(player, player.getTargetBlock(null, 1).getLocation());
```

I tested and it is working on my Paper 1.19.2 server.