### PR TITLE
/cc give-random

### DIFF
--- a/src/main/java/com/badbones69/crazycrates/api/CrazyManager.java
+++ b/src/main/java/com/badbones69/crazycrates/api/CrazyManager.java
@@ -1424,7 +1424,7 @@ public class CrazyManager {
         return ItemBuilder.convertStringList(file.getStringList("Crate.Prizes." + prize + ".Items"), prize);
     }
 
-    private long pickNumber(long min, long max) {
+    public long pickNumber(long min, long max) {
         max++;
 
         try {

--- a/src/main/java/com/badbones69/crazycrates/api/enums/Permissions.java
+++ b/src/main/java/com/badbones69/crazycrates/api/enums/Permissions.java
@@ -21,6 +21,7 @@ public enum Permissions {
     CRAZY_CRATES_ADMIN_FORCE_OPEN("admin.forceopen", "Opens a crate for a player for free."),
     CRAZY_CRATES_ADMIN_TELEPORT("admin.teleport", "Teleports to a crate."),
     CRAZY_CRATES_ADMIN_GIVE_KEY("admin.givekey", "Give a key(s) to a player to use on a crate."),
+    CRAZY_CRATES_ADMIN_GIVE_RANDOM_KEY("admin.giverandomkey", "Give a random key(s) to a player to use on a crate."),
     CRAZY_CRATES_ADMIN_GIVE_ALL("admin.giveall", "Gives all online players keys to use on crates."),
     CRAZY_CRATES_ADMIN_TAKE_KEY("admin.takekey", "Allows you to take keys from a player."),
     CRAZY_CRATES_ADMIN_SET_CRATE("admin.set", "Set the block you are looking at as the specified crate."),

--- a/src/main/java/com/badbones69/crazycrates/commands/subs/CrateBaseCommand.java
+++ b/src/main/java/com/badbones69/crazycrates/commands/subs/CrateBaseCommand.java
@@ -481,6 +481,13 @@ public class CrateBaseCommand extends BaseCommand {
         player.sendMessage(Messages.NOT_A_CRATE.getMessage("%Crate%", crateName));
     }
 
+    @SubCommand("give-random")
+    @Permission(value = "crazycrates.command.admin.giverandomkey", def = PermissionDefault.OP)
+    public void onAdminCrateGiveRandom(CommandSender sender, @Suggestion("key-types") String keyType, @Suggestion("numbers") int amount, @Suggestion("online-players") Player target) {
+        Crate crate = crazyManager.getCrates().get((int) crazyManager.pickNumber(0, (crazyManager.getCrates().size() - 2)));
+        onAdminCrateGive(sender, keyType, crate.getName(), amount,  target);
+    }
+
     @SubCommand("give")
     @Permission(value = "crazycrates.command.admin.givekey", def = PermissionDefault.OP)
     public void onAdminCrateGive(CommandSender sender, @Suggestion("key-types") String keyType, @Suggestion("crates") String crateName, @Suggestion("numbers") int amount, @Suggestion("online-players") Player target) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -99,10 +99,14 @@ permissions:
   crazycrates.command.admin.givekey:
     default: op
 
+  crazycrates.command.admin.giverandomkey:
+    default: op
+
   crazycrates.command.admin.giveall:
     default: op
     children:
       crazycrates.command.admin.givekey: true
+      crazycrates.command.admin.giverandomkey: true
       crazycrates.command.admin.takekey: true
       crazycrates.command.player.transfer: true
 


### PR DESCRIPTION
A command that gives players a random key out of all of the crates that you have. 
Specify a number higher than 1 to give them more than 1 of said key.

Command: `/cc give-random <virtual/physical> <amount> <player>`
Permission node: `crazycrates.command.admin.giverandomkey`

