### PR TITLE
Fix modrinth publish task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 
     `maven-publish`
 
-    id("com.modrinth.minotaur") version "2.+"
+    id("com.modrinth.minotaur") version "2.5.0"
 
     id("com.github.johnrengelman.shadow") version "7.1.2"
 }
@@ -103,7 +103,7 @@ tasks {
             "org.bstats",
             "dev.triumphteam.cmd"
         ).forEach {
-            relocate(it, "${rootProject.group}.plugin.lib.$it")
+            relocate(it, "${project.group}.plugin.lib.$it")
         }
     }
 
@@ -113,7 +113,9 @@ tasks {
         versionName.set("${rootProject.name} ${project.version} Update")
         versionNumber.set("${project.version}")
         versionType.set("${extra["version_type"]}")
-        uploadFile.set(jar(project.name))
+        uploadFile.set(shadowJar.get())
+
+        autoAddDependsOn.set(true)
 
         gameVersions.addAll(listOf("1.19", "1.19.1", "1.19.2", "1.19.3"))
         loaders.addAll(listOf("paper", "purpur"))
@@ -153,8 +155,4 @@ publishing {
             from(components["java"])
         }
     }
-}
-
-fun jar(name: String): RegularFile {
-    return rootProject.layout.buildDirectory.file("libs/${name}-${project.version}.jar").get();
 }


### PR DESCRIPTION
When the next modrinth release is ready, It will now push the proper jar automatically.