### PR TITLE
Max-Mass-Open for QuickCrate

### DIFF
--- a/paper/src/main/java/com/badbones69/crazycrates/cratetypes/QuickCrate.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/cratetypes/QuickCrate.java
@@ -51,7 +51,8 @@ public class QuickCrate implements Listener {
             // give the player the prizes
             for (;keys > 0; keys--) {
                 if (Methods.isInventoryFull(player)) break;
-                
+                if (keysUsed >= crate.getMaxMassOpen()) break;
+
                 Prize prize = crate.pickPrize(player);
                 crazyManager.givePrize(player, prize, crate);
                 plugin.getServer().getPluginManager().callEvent(new PlayerPrizeEvent(player, crate, crate.getName(), prize));

--- a/paper/src/main/resources/crates/QuickCrateExample.yml
+++ b/paper/src/main/resources/crates/QuickCrateExample.yml
@@ -6,6 +6,7 @@ Crate:
   CrateName: '&eClassic Crate'
   Preview-Name: '&eClassic Crate Preview'
   StartingKeys: 0
+  #Dictates the max amount of crates opened at once with /CrazyCrates mass-open or crouch + right click.
   Max-Mass-Open: 10
   InGUI: false
   Slot: 14


### PR DESCRIPTION
Add in the same value as from /cc mass-open to be used for the max amount that can be opened at a time with QuickCrate as they cause basically the same amount of lag.