### PR TITLE
feature: Simple Discord webhook task

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -8,4 +8,11 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21")
+
+    // For the webhook tasks, this applies to the build-logic only
+    implementation("io.ktor:ktor-client-core:2.2.2")
+    implementation("io.ktor:ktor-client-cio:2.2.2")
+    implementation("io.ktor:ktor-client-content-negotiation:2.2.2")
+    implementation("io.ktor:ktor-serialization-gson:2.2.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 }

--- a/build-logic/src/main/kotlin/crazycrates.root-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/crazycrates.root-conventions.gradle.kts
@@ -1,0 +1,24 @@
+import task.ReleaseWebhook
+import task.WebhookExtension
+
+plugins {
+    `java-library`
+}
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+}
+
+tasks {
+    // Creating the extension to be available on the root gradle
+    val webhookExtension = extensions.create("webhook", WebhookExtension::class)
+
+    // Register the task
+    register<ReleaseWebhook>("releaseWebhook") {
+        extension = webhookExtension
+    }
+
+    compileJava {
+        options.release.set(17)
+    }
+}

--- a/build-logic/src/main/kotlin/task/ReleaseWebhook.kt
+++ b/build-logic/src/main/kotlin/task/ReleaseWebhook.kt
@@ -1,0 +1,51 @@
+package task
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.append
+import io.ktor.serialization.gson.gson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.extra
+
+/** Task to send webhooks to discord. */
+abstract class ReleaseWebhook : DefaultTask() {
+
+    /** Configured extension. */
+    @get:Input
+    lateinit var extension: WebhookExtension
+
+    /** Ktor client for easy requests. */
+    private val client = HttpClient(CIO) {
+        install(ContentNegotiation) {
+            gson()
+        }
+    }
+
+    @TaskAction
+    fun webhook() {
+        // The webhook url configured in the gradle.properties
+        val url = project.extra["discord.webhook.url"].toString()
+
+        runBlocking(Dispatchers.IO) {
+            val response = client.post(url) {
+                headers {
+                    append(HttpHeaders.ContentType, ContentType.Application.Json)
+                }
+                setBody(extension.build())
+            }
+
+            // Should be using logger, but eh
+            println("Webhook result: ${response.status}")
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/task/WebhookExtension.kt
+++ b/build-logic/src/main/kotlin/task/WebhookExtension.kt
@@ -1,0 +1,192 @@
+package task
+
+import com.google.gson.annotations.SerializedName
+import org.gradle.api.GradleException
+import java.awt.Color
+import java.net.URL
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+/** Extension to simplify customizing the webhook. */
+abstract class WebhookExtension {
+
+    private var content: String = ""
+    private var username: String = ""
+    private var avatar: String = ""
+    private val embeds: MutableList<Embed> = mutableListOf()
+
+    fun content(content: String) {
+        this.content = content;
+    }
+
+    fun username(username: String) {
+        this.username = username;
+    }
+
+    fun avatar(avatar: String) {
+        this.avatar = avatar;
+    }
+
+    fun embeds(builder: EmbedsBuilder.() -> Unit) {
+        embeds.addAll(EmbedsBuilder().apply(builder).build())
+    }
+
+    internal fun build(): Webhook {
+        return Webhook(
+            content,
+            username,
+            avatar,
+            false,
+            embeds.toList()
+        )
+    }
+
+    class EmbedsBuilder {
+        private val embeds: MutableList<Embed> = mutableListOf()
+
+        fun embed(builder: EmbedBuilder.() -> Unit) {
+            embeds.add(EmbedBuilder().apply(builder).build())
+        }
+
+        internal fun build() = embeds.toList()
+    }
+
+    class EmbedBuilder {
+        private var title: String? = null
+        private var description: String? = null
+        private var url: String? = null
+        private var timestamp: String = ""
+        private var color: Int? = null
+        private var footer: Footer? = null
+        private var image: Image? = null
+        private var thumbnail: Image? = null
+        private var provider: Provider? = null
+        private var author: Author? = null
+        private var fields: List<Field>? = null
+
+        fun title(title: String) {
+            this.title = title
+        }
+
+        fun description(description: String) {
+            this.description = description
+        }
+
+        fun url(url: String) {
+            this.url = url
+        }
+
+        fun timestamp(date: LocalDateTime) {
+            this.timestamp = date.format(DateTimeFormatter.ISO_DATE_TIME)
+        }
+
+        fun color(color: Color) {
+            this.color = color.toInt()
+        }
+
+        fun footer(text: String, icon: String? = null) {
+            this.footer = Footer(text, icon)
+        }
+
+        fun image(url: String) {
+            this.image = Image(url)
+        }
+
+        fun thumbnail(url: String) {
+            this.thumbnail = Image(url)
+        }
+
+        fun provider(name: String? = null, url: String? = null) {
+            this.provider = Provider(name, url)
+        }
+
+        fun author(name: String, url: String? = null, icon: String? = null) {
+            this.author = Author(name, url, icon)
+        }
+
+        fun fields(builder: FieldsBuilder.() -> Unit) {
+            this.fields = FieldsBuilder().apply(builder).build()
+        }
+
+        internal fun build() = Embed(
+            title,
+            description,
+            url,
+            timestamp,
+            color,
+            footer,
+            image,
+            thumbnail,
+            provider,
+            author,
+            fields,
+        )
+    }
+
+    class FieldsBuilder {
+        private val fields: MutableList<Field> = mutableListOf()
+
+        fun field(name: String, value: String, inline: Boolean = false) {
+            fields.add(Field(name, value, inline))
+        }
+
+        internal fun build() = fields.toList()
+    }
+
+    data class Webhook(
+        val content: String,
+        val username: String,
+        @SerializedName("avatar_url") val avatarUrl: String,
+        val tts: Boolean,
+        val embeds: List<Embed>,
+    )
+
+    data class Embed(
+        val title: String?,
+        val description: String?,
+        val url: String?,
+        val timestamp: String,
+        val color: Int?,
+        val footer: Footer?,
+        val image: Image?,
+        val thumbnail: Image?,
+        val provider: Provider?,
+        val author: Author?,
+        val fields: List<Field>?,
+    )
+
+    data class Image(
+        val url: String,
+    )
+
+    data class Author(
+        val name: String,
+        val url: String?,
+        @SerializedName("icon_url") val iconUrl: String?,
+    )
+
+    data class Provider(
+        val name: String?,
+        val url: String?,
+    )
+
+    data class Footer(
+        val text: String,
+        @SerializedName("icon_url") val iconUrl: String?,
+    )
+
+    data class Field(
+        val name: String,
+        val value: String,
+        val inline: Boolean?,
+    )
+}
+
+/** Turns color into integer for webhook, using this because [Color]'s rgb method returns negatives. */
+private fun Color.toInt(): Int {
+    val red = red shl 16 and 0xFF0000
+    val green = green shl 8 and 0x00FF00
+    val blue = blue and 0x0000FF
+
+    return red or green or blue
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,1 +1,8 @@
+import java.net.URL
+import java.awt.Color
+
+plugins {
+    id("crazycrates.root-conventions")
+}
+
 rootProject.group = "${extra["plugin_group"]}"


### PR DESCRIPTION
To configure make sure to add the `webhook` extension to the root `build.gradle.kts` and the webhook URL into the `gradle.properties` in the **user**'s `.gradle` folder under the key `discord.webhook.url`, don't put it in the project, keep it private.
To run simply run the task `releaseWebhook`, feel free to rename it in the root conventions plugin.