### PR TITLE
Crate Open Permission

### DIFF
--- a/paper/src/main/java/com/badbones69/crazycrates/paper/api/CrazyManager.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/paper/api/CrazyManager.java
@@ -339,6 +339,11 @@ public class CrazyManager {
             }
         }
 
+        if (!(player.hasPermission("crazycrates.open." + crate.getName()) || player.hasPermission("crazycrates.open.*"))) {
+            player.sendMessage(Messages.NO_CRATE_PERMISSION.getMessage());
+            return;
+        }
+
         addPlayerToOpeningList(player, crate);
 
         if (crate.getFile() != null) Methods.broadCastMessage(crate.getFile(), player);

--- a/paper/src/main/java/com/badbones69/crazycrates/paper/api/CrazyManager.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/paper/api/CrazyManager.java
@@ -341,7 +341,8 @@ public class CrazyManager {
 
         if (!(player.hasPermission("crazycrates.open." + crate.getName()) || player.hasPermission("crazycrates.open.*"))) {
             player.sendMessage(Messages.NO_CRATE_PERMISSION.getMessage());
-            if (CrateControlListener.inUse.containsValue(location)) CrateControlListener.inUse.remove(player);
+            removePlayerFromOpeningList(player);
+            CrateControlListener.inUse.remove(player);
             return;
         }
 

--- a/paper/src/main/java/com/badbones69/crazycrates/paper/api/CrazyManager.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/paper/api/CrazyManager.java
@@ -341,6 +341,7 @@ public class CrazyManager {
 
         if (!(player.hasPermission("crazycrates.open." + crate.getName()) || player.hasPermission("crazycrates.open.*"))) {
             player.sendMessage(Messages.NO_CRATE_PERMISSION.getMessage());
+            if (CrateControlListener.inUse.containsValue(location)) CrateControlListener.inUse.remove(player);
             return;
         }
 

--- a/paper/src/main/java/com/badbones69/crazycrates/paper/api/enums/settings/Messages.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/paper/api/enums/settings/Messages.java
@@ -21,6 +21,7 @@ public enum Messages {
     RELOAD("Reload", "&3You have reloaded the Config and Data Files."),
     NOT_ONLINE("Not-Online", "&cThe player &6%player% &cis not online at this time."),
     NO_PERMISSION("No-Permission", "&cYou do not have permission to use that command!"),
+    NO_CRATE_PERMISSION("No-Crate-Permission", "&cYou do not have permission to use that crate."),
     CRATE_ALREADY_OPENED("Crate-Already-Opened", "&cYou are already opening a Crate."),
     CANT_BE_A_VIRTUAL_CRATE("Cant-Be-A-Virtual-Crate", "&cThat crate type cannot be used as a Virtual Crate."),
     INVENTORY_FULL("Inventory-Full", "&cYour inventory is full, Please make room before opening a Crate."),

--- a/paper/src/main/resources/messages.yml
+++ b/paper/src/main/resources/messages.yml
@@ -11,6 +11,7 @@ Messages:
   Reload: '&3You have reloaded the Config and Data Files.'
   Not-Online: '&cThe player &6%player% &cis not online.'
   No-Permission: '&cYou do not have permission to use that command!'
+  No-Crate-Permission: "&cYou do not have permission to use that crate."
   Crate-Already-Opened: '&cYou are already opening a Crate.'
   Cant-Be-A-Virtual-Crate: '&cThat Crate type cannot be used as a Virtual Crate.'
   Inventory-Full: '&cYour inventory is full, Please make room before opening a Crate.'

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -147,3 +147,5 @@ permissions:
     default: op
     children:
       crazycrates.command.admin.reload: true
+  crazycrates.open.*:
+    default: true


### PR DESCRIPTION
### New Message 
- `No-Crate-Permission:`

### New Permissions
- `crazycrates.open.<crateName>` 
- `crazycrates.open.*` default: true


The current permission check and enum are based on command usage, but may need to be revised to better align with the rest of the code. Therefore permission checks were used the way that they currently are.