### PR TITLE
Remove Magic Number

### DIFF
--- a/paper/src/main/java/com/badbones69/crazycrates/paper/cratetypes/Cosmic.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/paper/cratetypes/Cosmic.java
@@ -296,8 +296,8 @@ public class Cosmic implements Listener {
         }
 
         if (crazyManager.isInOpeningList(player) && e.getView().getTitle().equals(Methods.sanitizeColor(crate.getFile().getString("Crate.CrateName") + " - Choose"))) {
-
-            if (!glass.containsKey(player) || glass.get(player).size() < 4) {
+            CosmicCrateManager manager = (CosmicCrateManager) crate.getManager();
+            if (!glass.containsKey(player) || glass.get(player).size() < manager.getTotalPrizes()) {
                 crazyManager.removePlayerFromOpeningList(player);
                 crazyManager.removePlayerKeyType(player);
             }

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -10,9 +10,6 @@ website: '${website}'
 
 softdepend: [CMI, DecentHolograms, HolographicDisplays, PlaceholderAPI, ItemsAdder, Oraxen]
 
-loadbefore:
-  - Multiverse-Core
-
 commands:
   crates:
     description: The base command for Crazy Crates


### PR DESCRIPTION
Remove the magic number that caused the cosmic-crate type to always break when players set the amount to less than 4.