### PR TITLE
Replace crate open permission with deny open permission

### DIFF
--- a/paper/src/main/java/us/crazycrew/crazycrates/paper/listeners/crates/CrateOpenListener.java
+++ b/paper/src/main/java/us/crazycrew/crazycrates/paper/listeners/crates/CrateOpenListener.java
@@ -49,7 +49,7 @@ public class CrateOpenListener implements Listener {
             }
         }
 
-        if (!(player.hasPermission("crazycrates.open." + crate.getName()) || player.hasPermission("crazycrates.open.*"))) {
+        if (player.hasPermission("crazycrates.deny.open." + crate.getName())) {
             player.sendMessage(Translation.no_crate_permission.getString());
             this.crateManager.removePlayerFromOpeningList(player);
             CrateControlListener.inUse.remove(player);

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -149,6 +149,3 @@ permissions:
     default: op
     children:
       crazycrates.command.admin.reload: true
-
-  crazycrates.open.*:
-    default: true


### PR DESCRIPTION
Changed crate open permission over to being a deny open permission. This change should simplify how crate permissions are handled by reducing it to a single permission per crate that is more self-explanatory.

With this change, OPed players will by default not be able to open crates due to them having all permissions.
Currently, I am not sure if I should make it never deny OPed players from opening crates, or if it should be left as is.