### PR TITLE
Update buildscript

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,9 +20,13 @@ tasks {
             doLast {
                 runCatching {
                     if (project.name != "api") {
+                        val file = File("$jarsDir/${project.name.uppercaseFirstChar()}")
+
+                        file.mkdirs()
+
                         copy {
-                            from(project.layout.buildDirectory.file("libs/${rootProject.name}-${project.name.uppercaseFirstChar()}-${project.version}.jar"))
-                            into(jarsDir)
+                            from(project.layout.buildDirectory.file("libs/${rootProject.name}-${project.version}.jar"))
+                            into(file)
                         }
                     }
                 }.onSuccess {

--- a/buildSrc/src/main/kotlin/fabric-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/fabric-plugin.gradle.kts
@@ -1,11 +1,9 @@
-import org.gradle.kotlin.dsl.support.uppercaseFirstChar
-
 plugins {
     id("root-plugin")
 }
 
 base {
-    archivesName.set("${rootProject.name}-${project.name.uppercaseFirstChar()}")
+    archivesName.set(rootProject.name)
 }
 
 val mcVersion = providers.gradleProperty("mcVersion")
@@ -14,12 +12,7 @@ val fabricVersion = providers.gradleProperty("version")
 project.version = if (System.getenv("BUILD_NUMBER") != null) "$fabricVersion-${System.getenv("BUILD_NUMBER")}" else fabricVersion
 
 tasks {
-    val isBeta: Boolean = providers.gradleProperty("isBeta").get().toBoolean()
-    val type = if (isBeta) "Beta" else "Release"
-
     modrinth {
-        versionType.set(type.lowercase())
-
         loaders.addAll("fabric")
     }
 }

--- a/buildSrc/src/main/kotlin/paper-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/paper-plugin.gradle.kts
@@ -1,11 +1,4 @@
-import gradle.kotlin.dsl.accessors._3c6de1dd92ae3b7d1ad54590cc9ae150.base
-import io.papermc.hangarpublishplugin.model.Platforms
-import org.gradle.kotlin.dsl.support.uppercaseFirstChar
-import java.io.ByteArrayOutputStream
-
 plugins {
-    id("io.papermc.hangar-publish-plugin")
-
     id("io.papermc.paperweight.userdev")
 
     id("xyz.jpenilla.run-paper")
@@ -14,7 +7,7 @@ plugins {
 }
 
 base {
-    archivesName.set("${rootProject.name}-${project.name.uppercaseFirstChar()}")
+    archivesName.set(rootProject.name)
 }
 
 repositories {
@@ -39,44 +32,6 @@ dependencies {
     paperweight.paperDevBundle("$mcVersion-R0.1-SNAPSHOT")
 }
 
-// The commit id for the "main" branch prior to merging a pull request.
-val start = "e888a19"
-
-// The commit id BEFORE merging the pull request so before "Merge pull request #30"
-val end = "f78f454"
-
-val commitLog = getGitHistory().joinToString(separator = "") { formatGitLog(it) }
-
-fun getGitHistory(): List<String> {
-    val output: String = ByteArrayOutputStream().use { outputStream ->
-        project.exec {
-            executable("git")
-            args("log",  "$start..$end", "--format=format:%h %s")
-            standardOutput = outputStream
-        }
-
-        outputStream.toString()
-    }
-
-    return output.split("\n")
-}
-
-fun formatGitLog(commitLog: String): String {
-    val hash = commitLog.take(7)
-    val message = commitLog.substring(8) // Get message after commit hash + space between
-    return "[$hash](https://github.com/Crazy-Crew/${rootProject.name}/commit/$hash) $message<br>"
-}
-
-val changes = """
-${rootProject.file("CHANGELOG.md").readText(Charsets.UTF_8)} 
-## Commits  
-<details>  
-<summary>Other</summary>
-
-$commitLog
-</details>
-""".trimIndent()
-
 tasks {
     assemble {
         dependsOn(reobfJar)
@@ -90,38 +45,7 @@ tasks {
         minecraftVersion(mcVersion)
     }
 
-    val directory = File("$rootDir/jars")
-    val isBeta: Boolean = providers.gradleProperty("isBeta").get().toBoolean()
-    val type = if (isBeta) "Beta" else "Release"
-
-    // Publish to hangar.papermc.io.
-    hangarPublish {
-        publications.register("plugin") {
-            version.set("${project.version}")
-
-            id.set(rootProject.name)
-
-            channel.set(type)
-
-            changelog.set(changes)
-
-            apiKey.set(System.getenv("hangar_key"))
-
-            platforms {
-                register(Platforms.PAPER) {
-                    jar.set(file("$directory/${rootProject.name}-${project.name.uppercaseFirstChar()}-${project.version}.jar"))
-
-                    platformVersions.set(listOf(mcVersion))
-                }
-            }
-        }
-    }
-
     modrinth {
-        versionType.set(type.lowercase())
-
-        changelog.set(changes)
-
         loaders.addAll("paper", "purpur")
     }
 }

--- a/buildSrc/src/main/kotlin/root-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/root-plugin.gradle.kts
@@ -1,6 +1,10 @@
+import io.papermc.hangarpublishplugin.model.Platforms
 import org.gradle.kotlin.dsl.support.uppercaseFirstChar
+import java.io.ByteArrayOutputStream
 
 plugins {
+    id("io.papermc.hangar-publish-plugin")
+
     id("com.github.johnrengelman.shadow")
 
     id("com.modrinth.minotaur")
@@ -19,6 +23,44 @@ repositories {
 
     mavenCentral()
 }
+
+// The commit id for the "main" branch prior to merging a pull request.
+val start = "e888a19"
+
+// The commit id BEFORE merging the pull request so before "Merge pull request #30"
+val end = "f78f454"
+
+val commitLog = getGitHistory().joinToString(separator = "") { formatGitLog(it) }
+
+fun getGitHistory(): List<String> {
+    val output: String = ByteArrayOutputStream().use { outputStream ->
+        project.exec {
+            executable("git")
+            args("log",  "$start..$end", "--format=format:%h %s")
+            standardOutput = outputStream
+        }
+
+        outputStream.toString()
+    }
+
+    return output.split("\n")
+}
+
+fun formatGitLog(commitLog: String): String {
+    val hash = commitLog.take(7)
+    val message = commitLog.substring(8) // Get message after commit hash + space between
+    return "[$hash](https://github.com/Crazy-Crew/${rootProject.name}/commit/$hash) $message<br>"
+}
+
+val changes = """
+${rootProject.file("CHANGELOG.md").readText(Charsets.UTF_8)} 
+## Commits  
+<details>  
+<summary>Other</summary>
+
+$commitLog
+</details>
+""".trimIndent()
 
 tasks {
     compileJava {
@@ -43,18 +85,48 @@ tasks {
     val directory = File("$rootDir/jars")
     val mcVersion = providers.gradleProperty("mcVersion").get()
 
+    val isBeta: Boolean = providers.gradleProperty("isBeta").get().toBoolean()
+    val type = if (isBeta) "Beta" else "Release"
+
+    // Publish to hangar.papermc.io.
+    hangarPublish {
+        publications.register("plugin") {
+            version.set("${project.version}")
+
+            id.set(rootProject.name)
+
+            channel.set(type)
+
+            changelog.set(changes)
+
+            apiKey.set(System.getenv("hangar_key"))
+
+            platforms {
+                register(Platforms.PAPER) {
+                    jar.set(file("$directory/${rootProject.name}-${project.version}.jar"))
+
+                    platformVersions.set(listOf(mcVersion))
+                }
+            }
+        }
+    }
+
     modrinth {
+        versionType.set(type.lowercase())
+
         autoAddDependsOn.set(false)
 
         token.set(System.getenv("modrinth_token"))
 
         projectId.set(rootProject.name.lowercase())
 
+        changelog.set(changes)
+
         versionName.set("${rootProject.name} ${project.version}")
 
         versionNumber.set("${project.version}")
 
-        uploadFile.set("$directory/${rootProject.name}-${project.name.uppercaseFirstChar()}-${project.version}.jar")
+        uploadFile.set("$directory/${rootProject.name}-${project.version}.jar")
 
         gameVersions.add(mcVersion)
     }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("fabric-plugin")
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ description = Add unlimited crates to your server with 10 different crate types 
 version = 1.21
 apiVersion = 1.20
 
-mcVersion=1.20.4
+mcVersion = 1.20.4
 isBeta = false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,5 +47,5 @@ rootProject.name = "CrazyCrates"
 
 include("api")
 include("paper")
-//include("fabric")
+include("fabric")
 include("common")


### PR DESCRIPTION
Changes how publishing to modrinth/hangar is handled as well as where jars built using the assemble task go.

Before, each jar depending on the module had the module name in the jar name but now they are separated into folders in the jars folder based on the module name.

The jars being separated are simply for jenkins archiving. 

Fabric and Paper versions of CrazyCrates will often be on separate versions so this was a needed change.