### PR TITLE
Fixes an issue where prizes were picked incorrectly.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ issues = https://github.com/Crazy-Crew/CrazyCrates/issues
 
 group = com.badbones69.crazycrates
 description = Add unlimited crates to your server with 10 different crate types to choose from!
-version = 2.0.4
+version = 2.0.5
 apiVersion = 1.20
 
 mcVersion = 1.20.4

--- a/paper/src/main/java/com/badbones69/crazycrates/api/objects/Crate.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/api/objects/Crate.java
@@ -557,7 +557,7 @@ public class Crate {
      */
     public Prize getPrize(String name) {
         for (Prize prize : this.prizes) {
-            if (prize.getPrizeName().equalsIgnoreCase(name)) return prize;
+            if (prize.getPrizeNumber().equalsIgnoreCase(name)) return prize;
         }
 
         return null;

--- a/paper/src/main/java/com/badbones69/crazycrates/api/objects/Prize.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/api/objects/Prize.java
@@ -97,7 +97,7 @@ public class Prize {
 
         this.section = section;
     }
-    
+
     /**
      * @return the name of the prize.
      */
@@ -118,7 +118,7 @@ public class Prize {
     public ItemStack getDisplayItem() {
         ItemStack itemStack = this.displayItem.build();
 
-        itemStack.editMeta(itemMeta -> itemMeta.getPersistentDataContainer().set(PersistentKeys.crate_prize.getNamespacedKey(), PersistentDataType.STRING, this.prizeName));
+        itemStack.editMeta(itemMeta -> itemMeta.getPersistentDataContainer().set(PersistentKeys.crate_prize.getNamespacedKey(), PersistentDataType.STRING, this.prizeNumber));
 
         return itemStack;
     }
@@ -129,7 +129,7 @@ public class Prize {
     public ItemStack getDisplayItem(Player player) {
         ItemStack itemStack = this.displayItem.setTarget(player).build();
 
-        itemStack.editMeta(itemMeta -> itemMeta.getPersistentDataContainer().set(PersistentKeys.crate_prize.getNamespacedKey(), PersistentDataType.STRING, this.prizeName));
+        itemStack.editMeta(itemMeta -> itemMeta.getPersistentDataContainer().set(PersistentKeys.crate_prize.getNamespacedKey(), PersistentDataType.STRING, this.prizeNumber));
 
         return itemStack;
     }


### PR DESCRIPTION
The issue was I was using a method that got the `DisplayName` of the item which is only for previews. If the display name of 2 prizes were exactly the same. It would just get confused and not give prizes correctly.

getPrizeNumber() returns `1` which is what we want when picking prizes.

This is likely the last update for 1.20.4 unless another bug shows up.

```yml
Crate:
  Prizes:
    1:
      DisplayName: "&cAn example of a Player Head!"
```