### PR TITLE
Lores are stupid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
-## Changes:
-* Updated the message in commands, instead of `misc.no-virtual-keys`, It will be using `misc.no-keys` message
-
 ## Fixes:
-* Send the message to the command sender instead of the player when using `/crates forceopen`
+* Updates how lore is handled when using /cc additem
 
 ## Other:
 * [Feature Requests](https://github.com/Crazy-Crew/CrazyCrates/discussions/categories/features)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,6 @@ plugins {
 
 val isSnapshot = false
 
-rootProject.version = "3.0"
-
 val content: String = rootProject.file("CHANGELOG.md").readText(Charsets.UTF_8)
 
 subprojects.filter { it.name != "api" }.forEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ authors=["ryderbelserion", "BadBones69", "TDL"]
 description=Create unlimited crates with multiple crate types to choose from!
 website=https://modrinth.com/plugin/crazycrates
 
-version=3.0
+version=3.0.1

--- a/paper/run/server.properties
+++ b/paper/run/server.properties
@@ -1,5 +1,5 @@
 #Minecraft server properties
-#Thu May 23 14:31:31 EDT 2024
+#Mon Jun 03 12:01:59 EDT 2024
 accepts-transfers=false
 allow-flight=false
 allow-nether=false

--- a/paper/src/main/java/com/badbones69/crazycrates/api/objects/Crate.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/api/objects/Crate.java
@@ -8,10 +8,13 @@ import com.badbones69.crazycrates.tasks.crates.CrateManager;
 import com.badbones69.crazycrates.tasks.crates.effects.SoundEffect;
 import com.ryderbelserion.vital.core.config.objects.CustomFile;
 import com.ryderbelserion.vital.core.util.AdvUtil;
+import com.ryderbelserion.vital.core.util.StringUtil;
 import com.ryderbelserion.vital.paper.builders.items.ItemBuilder;
 import com.ryderbelserion.vital.paper.util.DyeUtil;
 import com.ryderbelserion.vital.paper.util.ItemUtil;
 import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.json.JSONComponentSerializer;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.Particle;
@@ -741,7 +744,15 @@ public class Crate {
                 }
 
                 if (itemMeta.hasLore()) {
-                    section.set(getPath(prizeName, "DisplayLore"), itemMeta.lore());
+                    List<Component> lores = itemMeta.lore();
+
+                    if (lores != null) {
+                        List<String> lore = new ArrayList<>();
+
+                        lores.forEach(line -> lore.add(JSONComponentSerializer.json().serialize(line)));
+
+                        section.set(getPath(prizeName, "DisplayLore"), lore);
+                    }
                 }
 
                 if (itemMeta.hasDisplayName()) {

--- a/paper/src/main/java/com/badbones69/crazycrates/api/objects/Prize.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/api/objects/Prize.java
@@ -3,6 +3,8 @@ package com.badbones69.crazycrates.api.objects;
 import com.badbones69.crazycrates.api.enums.PersistentKeys;
 import com.badbones69.crazycrates.api.utils.ItemUtils;
 import com.ryderbelserion.vital.paper.builders.items.ItemBuilder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.json.JSONComponentSerializer;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -203,7 +205,7 @@ public class Prize {
     }
 
     private @NotNull ItemBuilder display() {
-        final ItemBuilder builder = new ItemBuilder();
+        ItemBuilder builder = new ItemBuilder();
 
         try {
             final String material = this.section.getString("DisplayItem", "red_terracotta");
@@ -211,11 +213,24 @@ public class Prize {
 
             builder.withType(material).setAmount(amount).setDisplayName(this.prizeName);
 
+            if (this.section.contains("DisplayLore")) {
+                // Temp fix until I update the ItemBuilder
+                List<Component> displayLore = new ArrayList<>();
+
+                this.section.getStringList("DisplayLore").forEach(line -> displayLore.add(JSONComponentSerializer.json().deserialize(line)));
+
+                ItemStack itemStack = builder.getStack();
+
+                itemStack.editMeta(itemMeta -> itemMeta.lore(displayLore));
+
+                builder = new ItemBuilder(itemStack);
+            } else {
+                builder.setDisplayLore(this.section.getStringList("Lore"));
+            }
+
             builder.setGlowing(this.section.contains("Glowing") ? section.getBoolean("Glowing") : null);
 
             builder.setDamage(this.section.getInt("DisplayDamage", 0));
-
-            builder.setDisplayLore(this.section.getStringList("Lore"));
 
             builder.addPatterns(this.section.getStringList("Patterns"));
 


### PR DESCRIPTION
This pull request deserializes and re-serializes the lore when read/writing from configuration

It builds the item stack if DisplayLore is found, converts the lore to components and then sets it to the item meta then creates a new itembuilder object then carries on like normal.