### PR TITLE
fix: default prize commands run even when a prize has commands set

### DIFF
--- a/paper/src/main/java/com/badbones69/crazycrates/api/PrizeManager.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/api/PrizeManager.java
@@ -184,8 +184,10 @@ public class PrizeManager {
             }
         }
 
-        for (final String command : crate.getPrizeCommands()) {
-            runCommands(player, prize, crate, command);
+        if (!crate.getPrizeCommands().isEmpty() && prize.getCommands().isEmpty()) {
+            for (final String command : crate.getPrizeCommands()) {
+                runCommands(player, prize, crate, command);
+            }
         }
 
         for (final String command : prize.getCommands()) {


### PR DESCRIPTION
When a prize has commands set, the default prize-commands are not supposed to run, but they are. This PR adds the same if check that is present for the prize-messages below it.