### PR TITLE
Fix Tier Prize Selection

### DIFF
--- a/paper/src/main/java/com/badbones69/crazycrates/paper/api/objects/Crate.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/paper/api/objects/Crate.java
@@ -421,7 +421,7 @@ public class Crate {
      * @return {@link Prize}
      */
     private Prize getPrize(@NotNull final List<Prize> prizes) {
-        double totalWeight = this.crateType == CrateType.casino || this.crateType == CrateType.cosmic ? prizes.stream().filter(prize -> prize.getWeight() == -1).mapToDouble(Prize::getWeight).sum() : this.sum;
+        double totalWeight = this.crateType == CrateType.casino || this.crateType == CrateType.cosmic ? prizes.stream().filter(prize -> prize.getWeight() != -1).mapToDouble(Prize::getWeight).sum() : this.sum;
 
         int index = 0;
 


### PR DESCRIPTION
Instead of always selecting the first prize of all tiers, pick a random one instead.