### PR TITLE
Fix crate giving on Folia and drop items on full inventory

### DIFF
--- a/paper/src/main/java/com/badbones69/crazycrates/paper/commands/crates/types/admin/keys/CommandGive.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/paper/commands/crates/types/admin/keys/CommandGive.java
@@ -109,12 +109,12 @@ public class CommandGive extends BaseCommand {
             final PlayerReceiveKeyEvent event = new PlayerReceiveKeyEvent(player, crate, PlayerReceiveKeyEvent.KeyReceiveReason.GIVE_ALL_COMMAND, amount);
             this.plugin.getServer().getPluginManager().callEvent(event);
 
-            if (event.isCancelled()) return;
+            if (event.isCancelled()) continue;
 
             if (crate.getCrateType() == CrateType.crate_on_the_go) {
                 MiscUtils.addItem(player, crate.getKey(amount, player));
 
-                return;
+                continue;
             }
 
             addKey(sender, player, crate, keyType, amount, isSilent, true);

--- a/paper/src/main/java/com/badbones69/crazycrates/paper/managers/BukkitUserManager.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/paper/managers/BukkitUserManager.java
@@ -138,13 +138,8 @@ public class BukkitUserManager extends UserManager {
 
         switch (keyType) {
             case physical_key -> {
-                if (!MiscUtils.isInventoryFull(player)) {
-                    MiscUtils.addItem(player, crate.getKey(amount, player));
 
-                    return;
-                }
-
-                if (config.getProperty(ConfigKeys.give_virtual_keys_when_inventory_full)) {
+                if (config.getProperty(ConfigKeys.give_virtual_keys_when_inventory_full) && MiscUtils.isInventoryFull(player)) {
                     addVirtualKeys(player.getUniqueId(), fileName, amount);
 
                     if (config.getProperty(ConfigKeys.notify_player_when_inventory_full)) {
@@ -161,7 +156,7 @@ public class BukkitUserManager extends UserManager {
                     return;
                 }
 
-                player.getWorld().dropItem(player.getLocation(), crate.getKey(amount, player));
+                MiscUtils.addItem(player, crate.getKey(amount, player));
             }
 
             case virtual_key -> addVirtualKeys(player.getUniqueId(), fileName, amount);

--- a/paper/src/main/java/com/badbones69/crazycrates/paper/utils/MiscUtils.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/paper/utils/MiscUtils.java
@@ -352,11 +352,17 @@ public class MiscUtils {
     }
 
     public static void addItem(@NotNull final Player player, @NotNull final ItemStack... items) {
-        final Inventory inventory = player.getInventory();
+        player.getScheduler().run(plugin, t -> {
+            final Inventory inventory = player.getInventory();
 
-        inventory.setMaxStackSize(64);
+            inventory.setMaxStackSize(64);
 
-        Arrays.asList(items).forEach(item -> inventory.addItem(item.clone()));
+            Arrays.asList(items).forEach(
+                item -> inventory.addItem(item.clone()).values().forEach(
+                    i -> player.getWorld().dropItem(player.getLocation(), i)
+                )
+            );
+        }, null);
     }
 
     /**


### PR DESCRIPTION
- Fixes #864
- Ensure crate items are dropped on the ground if the player's inventory is full
- Replaced incorrect `return` with `continue` in player loop to ensure all players are processed