### PR TITLE
feat: Log to console when keys are dropped via addKeys.

### DIFF
--- a/paper/src/main/java/com/badbones69/crazycrates/paper/managers/BukkitUserManager.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/paper/managers/BukkitUserManager.java
@@ -159,6 +159,15 @@ public class BukkitUserManager extends UserManager {
                 }
 
                 MiscUtils.dropItem(player, crate.getKey(amount, player), player.getLocation(), true);
+
+                this.logger.info("Dropped {} x{} key(s) for player {} at {} {} {} in world {}.",
+                        crate.getKeyName(),
+                        amount,
+                        player.getName(),
+                        (int)player.getLocation().x(),
+                        (int)player.getLocation().y(),
+                        (int)player.getLocation().z(),
+                        player.getWorld().getName());
             }
 
             case virtual_key -> addVirtualKeys(uuid, fileName, amount);


### PR DESCRIPTION
A common problem I get while running a network is when players say they didn't receive any keys. This logging should help eliminate the most likely possibility of their inventory being full.