### PR TITLE
Access chunk data on the owning region thread to restore Folia compatibility

### DIFF
--- a/paper/src/main/java/com/badbones69/crazycrates/paper/tasks/crates/CrateManager.java
+++ b/paper/src/main/java/com/badbones69/crazycrates/paper/tasks/crates/CrateManager.java
@@ -645,15 +645,19 @@ public class CrateManager {
                     continue;
                 }
 
-                final ChunkCrate chunk = new ChunkCrate(new Location(world, location.getX(), location.getY(), location.getZ())).init(location.getId());
-                final Location value = chunk.getLocation();
-                final String id = chunk.getId();
+                final Location value = new Location(world, location.getX(), location.getY(), location.getZ());
 
-                this.locations.put(id, new CrateLocation(id, crate, value)); // add to cache!
+                // Folia requires chunk access to happen on the thread of the region that owns the chunk.
+                this.server.getRegionScheduler().run(this.plugin, value, task -> {
+                    final ChunkCrate chunk = new ChunkCrate(value).init(location.getId());
+                    final String id = chunk.getId();
 
-                if (this.holograms != null && !crate.getCrateType().equals(CrateType.menu) && crate.getHologram().isEnabled()) {
-                    this.holograms.createHologram(value, crate, id);
-                }
+                    this.locations.put(id, new CrateLocation(id, crate, value)); // add to cache!
+
+                    if (this.holograms != null && !crate.getCrateType().equals(CrateType.menu) && crate.getHologram().isEnabled()) {
+                        this.holograms.createHologram(value, crate, id);
+                    }
+                });
             }
         }
 
@@ -702,7 +706,10 @@ public class CrateManager {
             this.holograms.removeHologram(id);
         }
 
-        new ChunkCrate(crateLocation.getLocation()).remove();
+        final Location removedLocation = crateLocation.getLocation();
+
+        // Folia requires chunk access to happen on the thread of the region that owns the chunk.
+        this.server.getRegionScheduler().run(this.plugin, removedLocation, task -> new ChunkCrate(removedLocation).remove());
 
         this.locations.remove(id);
 
@@ -801,13 +808,16 @@ public class CrateManager {
                 location.getBlockZ()
         );
 
-        new ChunkCrate(location).init(id);
+        // Folia requires chunk access to happen on the thread of the region that owns the chunk.
+        this.server.getRegionScheduler().run(this.plugin, location, task -> {
+            new ChunkCrate(location).init(id);
+
+            if (this.holograms != null && !crate.getCrateType().equals(CrateType.menu) && crate.getHologram().isEnabled()) {
+                this.holograms.createHologram(location, crate, id);
+            }
+        });
 
         this.locations.put(id, new CrateLocation(id, crate, location));
-
-        if (this.holograms != null && !crate.getCrateType().equals(CrateType.menu) && crate.getHologram().isEnabled()) {
-            this.holograms.createHologram(location, crate, id);
-        }
     }
 
     /**


### PR DESCRIPTION
## Description

The location loading fix in e58fa51 ("Fix an issue where only one location was loaded at a time", closes #926) introduced chunk access during plugin enable through `ChunkCrate` (`location.getChunk()` + persistent data container writes in `loadLocations()`).

On **Folia**, chunk access must happen on the thread of the region that owns the chunk. Folia's `ensureTickThread` throws `IllegalStateException: Chunk must be accessed on the region thread` for off-region access, so CrazyCrates now gets disabled on boot on every Folia server (tested against Folia 26.1.2).

## Changes

- `CrateManager.loadLocations()`: the per-location `ChunkCrate` init, cache insertion and hologram creation now run inside `RegionScheduler.run(...)` for that location.
- `CrateManager.addCrateLocation()`: same treatment (player-triggered `/crates set` path).
- `CrateManager.removeCrateByLocation()`: same treatment for the PDC cleanup.

On non-Folia Paper servers, the region scheduler simply executes on the main thread, so behavior there is unchanged.

## Testing

- Built from source and verified on **Folia 26.1.2**: boots clean with N>1 physical locations loaded (previously crashed and disabled the plugin), `/crates reload` keeps all locations alive, and `locations.yml` is rewritten without duplicates.
- Also verified live on a production SMP (Folia 26.1.2): 4/4 physical locations survive both a restart and a reload.